### PR TITLE
feat: Implement FastAPI application for tee time scraping and API access

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,131 +1,31 @@
-from sqlmodel import SQLModel, Field, create_engine, Session, select
+from fastapi import FastAPI
+from contextlib import asynccontextmanager
+from src.db import create_db_and_tables #, engine # engine might not be needed directly here
+from src.routers import tee_times_router # We'll create this next
 
-from src.courses.bally_haly import fetch_bally_tee_times, scrape_bally_tee_times
-from src.courses.glendenning import fetch_glendenning_tee_times, scrape_glendenning_tee_times
-from src.courses.pippy_park import fetch_pippy_tee_times, scrape_pippy_tee_times
-from src.courses.wilds import fetch_wilds_tee_times, scrape_wilds_tee_times
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Code to run on startup
+    print("Creating database and tables...")
+    create_db_and_tables()
+    yield
+    # Code to run on shutdown (if any)
 
-from src.models import Course, TeeTime
+app = FastAPI(
+    title="Tee Time API",
+    version="0.1.0",
+    description="API for accessing and managing golf tee times scraped from various public sources. Provides endpoints to trigger scraping and read course and tee time information.",
+    lifespan=lifespan
+)
 
-# Create DB
-engine = create_engine("sqlite:///teetimes.db")
-SQLModel.metadata.create_all(engine)
+app.include_router(tee_times_router.router, prefix="/api/v1")
 
-COURSES = [
-    Course(value="Championship SOUTH", label="Championship-SOUTH", resort="Bally Haly", holes=18, url="https://ballyhalygolf.totaleintegrated.com/Public-Tee-Times"),
-    Course(value="Executive NORTH", label="Executive-NORTH", resort="Bally Haly", holes=18, url="https://ballyhalygolf.totaleintegrated.com/Public-Tee-Times"),
-    Course(value="Admirals Green", label="ADMIRALS_GREEN", resort="Pippy Park", holes=18, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseGroupID=11757&CourseCode=ADMI&LoginType=5&BackTarget=com.teeon.teesheet.servlets.golfersection.ComboLanding&Referrer=www.pippypark.com"),
-    Course(value="Admirals Green 9 Hole", label="ADMIRALS_GREEN_9", resort="Pippy Park", holes=9, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseGroupID=11757&CourseCode=ADMI&LoginType=5&BackTarget=com.teeon.teesheet.servlets.golfersection.ComboLanding&Referrer=www.pippypark.com"),
-    Course(value="Captains Hill", label="CAPTAINS_HILL", resort="Pippy Park", holes=18, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseGroupID=11758&CourseCode=CAPT&LoginType=5&BackTarget=com.teeon.teesheet.servlets.golfersection.ComboLanding&Referrer=www.pippypark.com"),
-    Course(value="Glendenning", label="GLEDENNING", resort="Glendenning", holes=18, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseCode=GGGG&Referrer="),
-    Course(value="The Wilds", label="THE_WILDS", resort="The Wilds", holes=18, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseCode=SMRV&Referrer=thewilds.ca"),
-    Course(value="The Wilds 9 Hole", label="THE_WILDS_9", resort="The Wilds", holes=9, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseCode=SMRV&Referrer=thewilds.ca"),
-]
-
-def aggregate_and_deduplicate_tee_times(results: list[TeeTime]) -> list[TeeTime]:
-    seen = set()
-    deduped = []
-    for tee_time in results:
-        # Use a tuple of (date, time, course) as the unique key
-        key = (tee_time.date, tee_time.time, tee_time.course)
-        if key not in seen:
-            seen.add(key)
-            deduped.append(tee_time)
-    return deduped
-
-def insert_tee_times(tee_times: list[TeeTime]):
-    try:
-        with Session(engine) as session:
-            for tee_time in tee_times:
-                existing = session.exec(
-                    select(TeeTime).where(
-                        TeeTime.course_id == tee_time.course_id,
-                        TeeTime.time == tee_time.time,
-                        TeeTime.date == tee_time.date
-                    )
-                ).first()
-                if existing:
-                    existing.players = tee_time.players
-                    existing.price = tee_time.price
-                    # Add more fields if needed
-                else:
-                    session.add(tee_time)
-            session.commit()
-    except Exception as e:
-        session.rollback()
-        print(e)
-
-def insert_courses(courses: list[Course]):
-    try:
-        with Session(engine) as session:
-            for course in courses:
-                existing = session.exec(
-                    select(Course).where(Course.value == course.value)
-                ).first()
-                if existing:
-                    existing.label = course.label
-                    # Add more fields if needed
-                else:
-                    session.add(course)
-            session.commit()
-    except Exception as e:
-        session.rollback()
-        print(e)
-
-def get_course_by_id(course_id: int) -> Course:
-    with Session(engine) as session:
-        return session.exec(select(Course).where(Course.id == course_id)).first()
-    
-def get_courses_by_resort(resort: str) -> list[Course]:
-    with Session(engine) as session:
-        return session.exec(select(Course).where(Course.resort == resort)).all()
-
-def get_all_courses() -> list[Course]:
-    with Session(engine) as session:
-        return session.exec(select(Course)).all()
-
-def main():
-    bally_url = "https://ballyhalygolf.totaleintegrated.com/Public-Tee-Times"
-    EXECUTIVE_NORTH = "Executive-NORTH"
-    CHAMPIONSHIP_SOUTH = "Championship-SOUTH"
-
-    pippy_url = "https://www.pippypark.com/what-to-do/golfing/"
-    ADMIRALS_GREEN = "ADMIRALS_GREEN"
-    CAPTAINS_HILL = "CAPTAINS_HILL"
-
-    insert_courses(COURSES)
-
-    bally_courses = get_courses_by_resort("Bally Haly")
-    pippy_courses = get_courses_by_resort("Pippy Park")
-    glendenning_courses = get_courses_by_resort("Glendenning")
-    wilds_courses = get_courses_by_resort("The Wilds")
-    for course in bally_courses:
-        results = fetch_bally_tee_times("2025-05-23", course)
-        tee_times = scrape_bally_tee_times(results, course, "2025-05-23")
-        deduped_tee_times = aggregate_and_deduplicate_tee_times(tee_times)
-        insert_tee_times(deduped_tee_times)
-
-    for course in pippy_courses:
-        results = fetch_pippy_tee_times("2025-05-23", course)
-        tee_times = scrape_pippy_tee_times(results, course, "2025-05-23")
-        deduped_tee_times = aggregate_and_deduplicate_tee_times(tee_times)
-        insert_tee_times(deduped_tee_times)
-
-    for course in glendenning_courses:
-        results = fetch_glendenning_tee_times("2025-05-23", course)
-        tee_times = scrape_glendenning_tee_times(results, course, "2025-05-23")
-        deduped_tee_times = aggregate_and_deduplicate_tee_times(tee_times)
-        insert_tee_times(deduped_tee_times)
-
-    for course in wilds_courses:
-        results = fetch_wilds_tee_times("2025-05-23", course)
-        tee_times = scrape_wilds_tee_times(results, course, "2025-05-23")
-        deduped_tee_times = aggregate_and_deduplicate_tee_times(tee_times)
-        insert_tee_times(deduped_tee_times)
+@app.get("/")
+async def read_root():
+    return {"message": "Welcome to the Tee Time API. Navigate to /docs for API documentation."}
 
 if __name__ == "__main__":
-    import time
-    start_time = time.time()
-    main()
-    end_time = time.time()
-    print(f"\n\nTotal Time taken: {end_time - start_time:.2f} seconds\n")
+    import uvicorn
+    # Note: This is for local development. For production, use a process manager.
+    # The old main() function that runs scraping is no longer called here directly.
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, reload=True) # Added reload=True and "main:app" for uvicorn CLI

--- a/old_main.py
+++ b/old_main.py
@@ -1,0 +1,131 @@
+from sqlmodel import SQLModel, Field, create_engine, Session, select
+
+from src.courses.bally_haly import fetch_bally_tee_times, scrape_bally_tee_times
+from src.courses.glendenning import fetch_glendenning_tee_times, scrape_glendenning_tee_times
+from src.courses.pippy_park import fetch_pippy_tee_times, scrape_pippy_tee_times
+from src.courses.wilds import fetch_wilds_tee_times, scrape_wilds_tee_times
+
+from src.models import Course, TeeTime
+
+# Create DB
+engine = create_engine("sqlite:///teetimes.db")
+SQLModel.metadata.create_all(engine)
+
+COURSES = [
+    Course(value="Championship SOUTH", label="Championship-SOUTH", resort="Bally Haly", holes=18, url="https://ballyhalygolf.totaleintegrated.com/Public-Tee-Times"),
+    Course(value="Executive NORTH", label="Executive-NORTH", resort="Bally Haly", holes=18, url="https://ballyhalygolf.totaleintegrated.com/Public-Tee-Times"),
+    Course(value="Admirals Green", label="ADMIRALS_GREEN", resort="Pippy Park", holes=18, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseGroupID=11757&CourseCode=ADMI&LoginType=5&BackTarget=com.teeon.teesheet.servlets.golfersection.ComboLanding&Referrer=www.pippypark.com"),
+    Course(value="Admirals Green 9 Hole", label="ADMIRALS_GREEN_9", resort="Pippy Park", holes=9, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseGroupID=11757&CourseCode=ADMI&LoginType=5&BackTarget=com.teeon.teesheet.servlets.golfersection.ComboLanding&Referrer=www.pippypark.com"),
+    Course(value="Captains Hill", label="CAPTAINS_HILL", resort="Pippy Park", holes=18, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseGroupID=11758&CourseCode=CAPT&LoginType=5&BackTarget=com.teeon.teesheet.servlets.golfersection.ComboLanding&Referrer=www.pippypark.com"),
+    Course(value="Glendenning", label="GLEDENNING", resort="Glendenning", holes=18, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseCode=GGGG&Referrer="),
+    Course(value="The Wilds", label="THE_WILDS", resort="The Wilds", holes=18, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseCode=SMRV&Referrer=thewilds.ca"),
+    Course(value="The Wilds 9 Hole", label="THE_WILDS_9", resort="The Wilds", holes=9, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseCode=SMRV&Referrer=thewilds.ca"),
+]
+
+def aggregate_and_deduplicate_tee_times(results: list[TeeTime]) -> list[TeeTime]:
+    seen = set()
+    deduped = []
+    for tee_time in results:
+        # Use a tuple of (date, time, course) as the unique key
+        key = (tee_time.date, tee_time.time, tee_time.course)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(tee_time)
+    return deduped
+
+def insert_tee_times(tee_times: list[TeeTime]):
+    try:
+        with Session(engine) as session:
+            for tee_time in tee_times:
+                existing = session.exec(
+                    select(TeeTime).where(
+                        TeeTime.course_id == tee_time.course_id,
+                        TeeTime.time == tee_time.time,
+                        TeeTime.date == tee_time.date
+                    )
+                ).first()
+                if existing:
+                    existing.players = tee_time.players
+                    existing.price = tee_time.price
+                    # Add more fields if needed
+                else:
+                    session.add(tee_time)
+            session.commit()
+    except Exception as e:
+        session.rollback()
+        print(e)
+
+def insert_courses(courses: list[Course]):
+    try:
+        with Session(engine) as session:
+            for course in courses:
+                existing = session.exec(
+                    select(Course).where(Course.value == course.value)
+                ).first()
+                if existing:
+                    existing.label = course.label
+                    # Add more fields if needed
+                else:
+                    session.add(course)
+            session.commit()
+    except Exception as e:
+        session.rollback()
+        print(e)
+
+def get_course_by_id(course_id: int) -> Course:
+    with Session(engine) as session:
+        return session.exec(select(Course).where(Course.id == course_id)).first()
+    
+def get_courses_by_resort(resort: str) -> list[Course]:
+    with Session(engine) as session:
+        return session.exec(select(Course).where(Course.resort == resort)).all()
+
+def get_all_courses() -> list[Course]:
+    with Session(engine) as session:
+        return session.exec(select(Course)).all()
+
+def main():
+    bally_url = "https://ballyhalygolf.totaleintegrated.com/Public-Tee-Times"
+    EXECUTIVE_NORTH = "Executive-NORTH"
+    CHAMPIONSHIP_SOUTH = "Championship-SOUTH"
+
+    pippy_url = "https://www.pippypark.com/what-to-do/golfing/"
+    ADMIRALS_GREEN = "ADMIRALS_GREEN"
+    CAPTAINS_HILL = "CAPTAINS_HILL"
+
+    insert_courses(COURSES)
+
+    bally_courses = get_courses_by_resort("Bally Haly")
+    pippy_courses = get_courses_by_resort("Pippy Park")
+    glendenning_courses = get_courses_by_resort("Glendenning")
+    wilds_courses = get_courses_by_resort("The Wilds")
+    for course in bally_courses:
+        results = fetch_bally_tee_times("2025-05-23", course)
+        tee_times = scrape_bally_tee_times(results, course, "2025-05-23")
+        deduped_tee_times = aggregate_and_deduplicate_tee_times(tee_times)
+        insert_tee_times(deduped_tee_times)
+
+    for course in pippy_courses:
+        results = fetch_pippy_tee_times("2025-05-23", course)
+        tee_times = scrape_pippy_tee_times(results, course, "2025-05-23")
+        deduped_tee_times = aggregate_and_deduplicate_tee_times(tee_times)
+        insert_tee_times(deduped_tee_times)
+
+    for course in glendenning_courses:
+        results = fetch_glendenning_tee_times("2025-05-23", course)
+        tee_times = scrape_glendenning_tee_times(results, course, "2025-05-23")
+        deduped_tee_times = aggregate_and_deduplicate_tee_times(tee_times)
+        insert_tee_times(deduped_tee_times)
+
+    for course in wilds_courses:
+        results = fetch_wilds_tee_times("2025-05-23", course)
+        tee_times = scrape_wilds_tee_times(results, course, "2025-05-23")
+        deduped_tee_times = aggregate_and_deduplicate_tee_times(tee_times)
+        insert_tee_times(deduped_tee_times)
+
+if __name__ == "__main__":
+    import time
+    start_time = time.time()
+    main()
+    end_time = time.time()
+    print(f"\n\nTotal Time taken: {end_time - start_time:.2f} seconds\n")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,12 @@ dependencies = [
     "playwright>=1.52.0",
     "selectolax>=0.3.29",
     "sqlmodel>=0.0.24",
+    "fastapi>=0.100.0",
+    "uvicorn[standard]>=0.20.0",
+]
+
+[project.optional-dependencies]
+test = [
+    "pytest>=7.0",
+    "pytest-cov>=4.0",
 ]

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,90 @@
+from sqlmodel import SQLModel, create_engine, Session, select
+from typing import List, Optional # Add Optional for TeeTime | None
+
+# Import models from the models directory
+# Assuming models.py is in src.models
+from .models import Course, TeeTime # Adjusted import path
+
+DATABASE_URL = "sqlite:///teetimes.db"
+engine = create_engine(DATABASE_URL, echo=True) # Add echo for debugging if needed
+
+def create_db_and_tables():
+    SQLModel.metadata.create_all(engine)
+
+def get_session(): # Changed from get_db_session to get_session to match instructions
+    with Session(engine) as session:
+        yield session
+
+# Functions moved from old_main.py
+def insert_courses(courses: List[Course], db: Session): # Added db: Session parameter
+    try:
+        for course in courses:
+            existing = db.exec(
+                select(Course).where(Course.value == course.value)
+            ).first()
+            if existing:
+                existing.label = course.label
+                # Add more fields if needed
+            else:
+                db.add(course)
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        print(f"Error inserting courses: {e}") # Added f-string and error details
+
+def get_course_by_id(course_id: int, db: Session) -> Course: # Added db: Session parameter
+    return db.exec(select(Course).where(Course.id == course_id)).first()
+
+def get_courses_by_resort(resort: str, db: Session) -> List[Course]: # Added db: Session parameter
+    return db.exec(select(Course).where(Course.resort == resort)).all()
+
+def get_all_courses(db: Session) -> List[Course]: # Added db: Session parameter
+    return db.exec(select(Course)).all()
+
+def insert_tee_times(tee_times: List[TeeTime], db: Session): # Added db: Session parameter
+    try:
+        for tee_time in tee_times:
+            existing = db.exec(
+                select(TeeTime).where(
+                    TeeTime.course_id == tee_time.course_id,
+                    TeeTime.time == tee_time.time,
+                    TeeTime.date == tee_time.date
+                )
+            ).first()
+            if existing:
+                existing.players = tee_time.players
+                existing.price = tee_time.price
+                # Add more fields if needed
+            else:
+                db.add(tee_time)
+        db.commit()
+    except Exception as e:
+        db.rollback()
+        print(f"Error inserting tee times: {e}") # Added f-string and error details
+
+# New functions for querying tee times
+
+def get_all_tee_times(db: Session, skip: int = 0, limit: int = 100) -> List[TeeTime]:
+    """Queries and returns a list of all TeeTime objects with pagination."""
+    statement = select(TeeTime).offset(skip).limit(limit)
+    return db.exec(statement).all()
+
+def get_tee_times_by_date(date_str: str, db: Session, skip: int = 0, limit: int = 100) -> List[TeeTime]:
+    """Queries TeeTime objects filtering by the date field, with pagination."""
+    statement = select(TeeTime).where(TeeTime.date == date_str).offset(skip).limit(limit)
+    return db.exec(statement).all()
+
+def get_tee_times_by_course(course_id: int, db: Session, skip: int = 0, limit: int = 100) -> List[TeeTime]:
+    """Queries TeeTime objects filtering by course_id, with pagination."""
+    statement = select(TeeTime).where(TeeTime.course_id == course_id).offset(skip).limit(limit)
+    return db.exec(statement).all()
+
+def get_tee_time_by_id(tee_time_id: int, db: Session) -> Optional[TeeTime]: # Use Optional for TeeTime | None
+    """Queries for a single TeeTime by its id."""
+    statement = select(TeeTime).where(TeeTime.id == tee_time_id)
+    return db.exec(statement).first()
+
+def get_tee_times_by_course_and_date(course_id: int, date_str: str, db: Session, skip: int = 0, limit: int = 100) -> List[TeeTime]:
+    """Queries TeeTime objects filtering by both course_id and date, with pagination."""
+    statement = select(TeeTime).where(TeeTime.course_id == course_id, TeeTime.date == date_str).offset(skip).limit(limit)
+    return db.exec(statement).all()

--- a/src/models/course.py
+++ b/src/models/course.py
@@ -8,11 +8,21 @@ from sqlmodel import Field, Relationship, SQLModel
 
 
 class Course(SQLModel, table=True):
-    id: int | None = Field(default=None, primary_key=True)
+    id: int | None = Field(default=None, primary_key=True, description="Unique identifier for the course")
+    value: str = Field(description="Internal or scraper-specific value/identifier for the course, often used in URLs or scraping logic")
+    label: str = Field(unique=True, description="User-friendly display name for the course")
+    resort: str = Field(description="Name of the resort or club the course belongs to")
+    holes: int = Field(description="Number of holes the course has (e.g., 9 or 18)")
+    url: str = Field(description="Official URL for the course or its booking page")
+# No newline at end of file
+
+    tee_times: list["TeeTime"] = Relationship(back_populates="course")
+
+# Pydantic model for API responses (Read model)
+class CourseRead(SQLModel): # Inheriting from SQLModel is fine for response models
+    id: int
     value: str
-    label: str = Field(unique=True)
+    label: str
     resort: str
     holes: int
     url: str
-
-    tee_times: list["TeeTime"] = Relationship(back_populates="course")

--- a/src/models/tee_time.py
+++ b/src/models/tee_time.py
@@ -11,13 +11,29 @@ from sqlalchemy import UniqueConstraint
 
 
 class TeeTime(SQLModel, table=True):
-    id: int | None = Field(default=None, primary_key=True)
-    course_id: int = Field(foreign_key="course.id")
-    time: str
-    date: str
-    players: int
-    price: str
-    holes: int
+    id: int | None = Field(default=None, primary_key=True, description="Unique identifier for the tee time slot")
+    course_id: int = Field(foreign_key="course.id", description="Foreign key linking to the course this tee time belongs to")
+    time: str = Field(description="Tee time in HH:MM format (e.g., '08:30')")
+    date: str = Field(description="Date of the tee time in YYYY-MM-DD format (e.g., '2024-07-15')")
+    players: int = Field(description="Number of available player slots for this tee time")
+    price: str = Field(description="Price for this tee time, as a string (e.g., '55.00', may include currency symbols or text)") # Consider Decimal/float if processing
+    holes: int = Field(description="Number of holes this tee time is for (e.g., 9 or 18)")
 
     course: "Course" = Relationship(back_populates="tee_times")
     __table_args__ = (UniqueConstraint("course_id", "time", "date"),)
+
+# Pydantic model for API responses (Read model)
+# Need to import CourseRead from .course
+from typing import Optional # Ensure Optional is imported if not already
+from .course import CourseRead
+
+class TeeTimeRead(SQLModel): # Inheriting from SQLModel is fine
+    id: int
+    course_id: int
+    time: str
+    date: str
+    players: int
+    price: str 
+    holes: int
+    course: Optional[CourseRead] = None
+# No newline at end of file

--- a/src/routers/__init__.py
+++ b/src/routers/__init__.py
@@ -1,0 +1,7 @@
+# This file can be empty, or it can export symbols from router modules.
+# For example, you could import and re-export your routers here
+# from . import tee_times_router
+# from . import other_router
+
+# Or simply leave it empty if you prefer to import routers directly
+# from their respective modules in main.py or other app setup files.

--- a/src/routers/tee_times_router.py
+++ b/src/routers/tee_times_router.py
@@ -1,0 +1,171 @@
+from fastapi import APIRouter, Depends, HTTPException, Query, BackgroundTasks
+from sqlmodel import Session
+from typing import List, Optional
+from datetime import date as py_date, datetime
+
+from src.db import (
+    get_session,
+    get_all_tee_times,
+    get_tee_times_by_date,
+    get_tee_times_by_course,
+    get_tee_time_by_id,
+    get_tee_times_by_course_and_date,
+    get_all_courses,
+    get_course_by_id,
+    get_courses_by_resort
+)
+# Ensuring models are imported correctly for response_model hints
+from src.models import TeeTimeRead, CourseRead # Using Read models for responses
+from src.services.scraping_service import run_scheduled_scrape
+
+router = APIRouter(
+    prefix="/tee-times", 
+    tags=["Tee Times & Courses"], 
+)
+
+# Helper for date validation
+def validate_date_format(date_str: str) -> py_date:
+    """Helper function to validate date strings and convert to date objects."""
+    try:
+        return datetime.strptime(date_str, "%Y-%m-%d").date()
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid date format. Use YYYY-MM-DD.")
+
+# 1. Scraping Trigger Endpoint
+@router.post("/scrape", summary="Trigger a new scrape for tee times")
+async def trigger_scrape_endpoint(
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_session),
+    scrape_date_str: Optional[str] = Query(
+        None, 
+        description="Date to scrape in YYYY-MM-DD format. Defaults to today if not provided."
+    )
+):
+    """
+    Initiates the tee time scraping process for a specified date.
+    If no date is provided, scraping is done for the current day.
+    The process runs in the background.
+    """
+    actual_scrape_date_obj = None
+    if scrape_date_str:
+        actual_scrape_date_obj = validate_date_format(scrape_date_str)
+    else:
+        actual_scrape_date_obj = py_date.today()
+    
+    actual_scrape_date_str = actual_scrape_date_obj.strftime("%Y-%m-%d")
+    
+    background_tasks.add_task(run_scheduled_scrape, db, actual_scrape_date_str)
+    return {"message": "Scraping process initiated in the background.", "scrape_date": actual_scrape_date_str}
+
+# 2. Tee Time Read Endpoints
+
+@router.get("/", response_model=List[TeeTimeRead], summary="Get all tee times")
+async def read_all_tee_times_endpoint(
+    skip: int = Query(0, ge=0, description="Number of tee times to skip from the start."), 
+    limit: int = Query(100, ge=1, le=200, description="Maximum number of tee times to return."), 
+    db: Session = Depends(get_session)
+):
+    """
+    Retrieves a paginated list of all tee times available in the database.
+    Use 'skip' and 'limit' query parameters for pagination.
+    """
+    tee_times = get_all_tee_times(db=db, skip=skip, limit=limit)
+    return tee_times
+
+@router.get("/{tee_time_id}", response_model=TeeTimeRead, summary="Get tee time by ID")
+async def read_tee_time_by_id_endpoint(tee_time_id: int, db: Session = Depends(get_session)):
+    """
+    Retrieves a single tee time by its unique ID.
+    Returns a 404 error if the tee time is not found.
+    """
+    tee_time = get_tee_time_by_id(tee_time_id=tee_time_id, db=db)
+    if not tee_time:
+        raise HTTPException(status_code=404, detail="TeeTime not found")
+    return tee_time
+
+@router.get("/date/{date_str}", response_model=List[TeeTimeRead], summary="Get tee times by date")
+async def read_tee_times_by_date_str_endpoint(
+    date_str: str, 
+    skip: int = Query(0, ge=0, description="Number of tee times to skip."), 
+    limit: int = Query(100, ge=1, le=200, description="Maximum number of tee times to return."), 
+    db: Session = Depends(get_session)
+):
+    """
+    Retrieves a paginated list of tee times for a specific date.
+    Date must be in YYYY-MM-DD format.
+    """
+    validated_date = validate_date_format(date_str) 
+    tee_times = get_tee_times_by_date(date_str=validated_date.strftime("%Y-%m-%d"), db=db, skip=skip, limit=limit)
+    return tee_times
+
+@router.get("/course/{course_id}", response_model=List[TeeTimeRead], summary="Get tee times by course ID")
+async def read_tee_times_by_course_id_endpoint(
+    course_id: int, 
+    skip: int = Query(0, ge=0, description="Number of tee times to skip."), 
+    limit: int = Query(100, ge=1, le=200, description="Maximum number of tee times to return."), 
+    db: Session = Depends(get_session)
+):
+    """
+    Retrieves a paginated list of tee times for a specific course, identified by its ID.
+    """
+    # Optional: Check if course_id exists first could be added here if desired
+    # course = get_course_by_id(course_id=course_id, db=db)
+    # if not course:
+    #     raise HTTPException(status_code=404, detail=f"Course with id {course_id} not found.")
+    tee_times = get_tee_times_by_course(course_id=course_id, db=db, skip=skip, limit=limit)
+    return tee_times
+
+@router.get("/course/{course_id}/date/{date_str}", response_model=List[TeeTimeRead], summary="Get tee times by course ID and date")
+async def read_tee_times_by_course_id_and_date_str_endpoint(
+    course_id: int, 
+    date_str: str, 
+    skip: int = Query(0, ge=0, description="Number of tee times to skip."), 
+    limit: int = Query(100, ge=1, le=200, description="Maximum number of tee times to return."), 
+    db: Session = Depends(get_session)
+):
+    """
+    Retrieves a paginated list of tee times for a specific course ID and a specific date.
+    Date must be in YYYY-MM-DD format.
+    """
+    validated_date = validate_date_format(date_str)
+    # Optional: Check if course_id exists first
+    tee_times = get_tee_times_by_course_and_date(
+        course_id=course_id, 
+        date_str=validated_date.strftime("%Y-%m-%d"), 
+        db=db, 
+        skip=skip, 
+        limit=limit
+    )
+    return tee_times
+
+# 3. Course Read Endpoints
+
+@router.get("/courses/", response_model=List[CourseRead], summary="Get all courses")
+async def read_all_courses_endpoint(db: Session = Depends(get_session)):
+    """
+    Retrieves a list of all golf courses available in the database.
+    """
+    courses = get_all_courses(db=db)
+    return courses
+
+@router.get("/courses/{course_id}", response_model=CourseRead, summary="Get course by ID")
+async def read_course_by_id_endpoint(course_id: int, db: Session = Depends(get_session)):
+    """
+    Retrieves a single golf course by its unique ID.
+    Returns a 404 error if the course is not found.
+    """
+    course = get_course_by_id(course_id=course_id, db=db)
+    if not course:
+        raise HTTPException(status_code=404, detail="Course not found")
+    return course
+
+@router.get("/courses/resort/{resort_name}", response_model=List[CourseRead], summary="Get courses by resort name")
+async def read_courses_by_resort_name_endpoint(resort_name: str, db: Session = Depends(get_session)):
+    """
+    Retrieves a list of golf courses associated with a specific resort name.
+    Returns a 404 error if no courses are found for the given resort.
+    """
+    courses = get_courses_by_resort(resort=resort_name, db=db)
+    if not courses: 
+        raise HTTPException(status_code=404, detail=f"No courses found for resort: {resort_name}")
+    return courses

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,0 +1,1 @@
+# This file can be empty, or it can export symbols from the service modules.

--- a/src/services/scraping_service.py
+++ b/src/services/scraping_service.py
@@ -1,0 +1,119 @@
+from sqlmodel import Session
+# Adjusted imports to use functions from src.db and pass the session
+from src.db import get_session, insert_courses as db_insert_courses, insert_tee_times as db_insert_tee_times, get_courses_by_resort as db_get_courses_by_resort
+from src.models import Course, TeeTime # Assuming models are directly in src.models
+
+# Import course-specific scraping functions
+from src.courses.bally_haly import fetch_bally_tee_times, scrape_bally_tee_times
+from src.courses.glendenning import fetch_glendenning_tee_times, scrape_glendenning_tee_times
+from src.courses.pippy_park import fetch_pippy_tee_times, scrape_pippy_tee_times
+from src.courses.wilds import fetch_wilds_tee_times, scrape_wilds_tee_times
+
+# COURSES constant from old_main.py
+COURSES = [
+    Course(value="Championship SOUTH", label="Championship-SOUTH", resort="Bally Haly", holes=18, url="https://ballyhalygolf.totaleintegrated.com/Public-Tee-Times"),
+    Course(value="Executive NORTH", label="Executive-NORTH", resort="Bally Haly", holes=18, url="https://ballyhalygolf.totaleintegrated.com/Public-Tee-Times"),
+    Course(value="Admirals Green", label="ADMIRALS_GREEN", resort="Pippy Park", holes=18, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseGroupID=11757&CourseCode=ADMI&LoginType=5&BackTarget=com.teeon.teesheet.servlets.golfersection.ComboLanding&Referrer=www.pippypark.com"),
+    Course(value="Admirals Green 9 Hole", label="ADMIRALS_GREEN_9", resort="Pippy Park", holes=9, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseGroupID=11757&CourseCode=ADMI&LoginType=5&BackTarget=com.teeon.teesheet.servlets.golfersection.ComboLanding&Referrer=www.pippypark.com"),
+    Course(value="Captains Hill", label="CAPTAINS_HILL", resort="Pippy Park", holes=18, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseGroupID=11758&CourseCode=CAPT&LoginType=5&BackTarget=com.teeon.teesheet.servlets.golfersection.ComboLanding&Referrer=www.pippypark.com"),
+    Course(value="Glendenning", label="GLEDENNING", resort="Glendenning", holes=18, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseCode=GGGG&Referrer="),
+    Course(value="The Wilds", label="THE_WILDS", resort="The Wilds", holes=18, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseCode=SMRV&Referrer=thewilds.ca"),
+    Course(value="The Wilds 9 Hole", label="THE_WILDS_9", resort="The Wilds", holes=9, url="https://www.tee-on.com/PubGolf/servlet/com.teeon.teesheet.servlets.golfersection.WebBookingAllTimesLanding?CourseCode=SMRV&Referrer=thewilds.ca"),
+]
+
+def aggregate_and_deduplicate_tee_times(results: list[TeeTime]) -> list[TeeTime]:
+    seen = set()
+    deduped = []
+    for tee_time in results:
+        # Use a tuple of (date, time, course_id) as the unique key
+        # Assuming course_id is populated correctly before this function is called
+        key = (tee_time.date, tee_time.time, tee_time.course_id)
+        if key not in seen:
+            seen.add(key)
+            deduped.append(tee_time)
+    return deduped
+
+def run_scheduled_scrape(db: Session, scrape_date: str = "2025-05-23"): # Accepts a DB session and a date
+    """
+    Runs the scraping process for all configured courses and updates the database.
+    The scrape_date parameter is for demonstration; in a real scenario,
+    this would likely be the current date or a configurable date range.
+    """
+    print(f"Scraping and database update process started for date: {scrape_date}")
+
+    # Insert course definitions into the database
+    # This ensures courses are present before tee times are linked to them.
+    # In a real app, this might be a one-time setup or managed differently.
+    db_insert_courses(COURSES, db)
+    print(f"Inserted/Updated {len(COURSES)} courses in the database.")
+
+    all_scraped_tee_times = []
+
+    course_scraper_map = {
+        "Bally Haly": (fetch_bally_tee_times, scrape_bally_tee_times),
+        "Pippy Park": (fetch_pippy_tee_times, scrape_pippy_tee_times),
+        "Glendenning": (fetch_glendenning_tee_times, scrape_glendenning_tee_times),
+        "The Wilds": (fetch_wilds_tee_times, scrape_wilds_tee_times),
+    }
+
+    for resort_name, (fetch_func, scrape_func) in course_scraper_map.items():
+        print(f"Processing resort: {resort_name}")
+        courses_in_resort = db_get_courses_by_resort(resort_name, db)
+        if not courses_in_resort:
+            print(f"No courses found for resort: {resort_name}. Skipping.")
+            continue
+        
+        for course in courses_in_resort:
+            print(f"Fetching and scraping for course: {course.label} ({course.value})")
+            try:
+                # Ensure course.id is available for linking TeeTime.course_id
+                if course.id is None:
+                    # This should ideally not happen if courses are inserted first and IDs populated
+                    print(f"Warning: Course ID is None for {course.label}. Tee times may not link correctly.")
+                
+                raw_data = fetch_func(scrape_date, course) # Pass date and course object
+                # Scrape functions need to be adapted if they expect different params or if course_id needs to be set
+                tee_times = scrape_func(raw_data, course, scrape_date) # Pass date and course object
+                
+                # Ensure course_id is set on each tee_time if not already done by scrape_func
+                for tt in tee_times:
+                    tt.course_id = course.id
+
+                all_scraped_tee_times.extend(tee_times)
+                print(f"Found {len(tee_times)} tee times for {course.label}.")
+            except Exception as e:
+                print(f"Error scraping {course.label}: {e}")
+
+    if not all_scraped_tee_times:
+        print("No tee times were scraped across all courses.")
+    else:
+        print(f"Total tee times scraped before deduplication: {len(all_scraped_tee_times)}")
+        deduped_tee_times = aggregate_and_deduplicate_tee_times(all_scraped_tee_times)
+        print(f"Total tee times after deduplication: {len(deduped_tee_times)}")
+        
+        if deduped_tee_times:
+            db_insert_tee_times(deduped_tee_times, db)
+            print(f"Successfully inserted/updated {len(deduped_tee_times)} tee times in the database.")
+        else:
+            print("No new unique tee times to insert.")
+
+    print(f"Scraping and database update process completed for date: {scrape_date}")
+
+# Example of how to run this service (e.g., for a scheduled job or CLI command)
+# if __name__ == "__main__":
+#     import time
+#     from src.db import create_db_and_tables
+# 
+#     print("Initializing database...")
+#     create_db_and_tables() # Ensure DB is ready
+# 
+#     start_time = time.time()
+#     # Get a new session for the scrape
+#     db_session_generator = get_session()
+#     db = next(db_session_generator)
+#     try:
+#         run_scheduled_scrape(db=db, scrape_date="2025-07-01") # Example date
+#     finally:
+#         db.close() # Ensure session is closed
+#     end_time = time.time()
+#     print(f"\n\nTotal Time taken for scrape: {end_time - start_time:.2f} seconds\n")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,51 @@
+# tests/conftest.py
+import pytest
+from sqlmodel import SQLModel, create_engine, Session
+from fastapi.testclient import TestClient
+
+from src.db import get_session # Original get_session
+from src.main import app # Your FastAPI app
+from src.models import Course, TeeTime # Import your models
+
+# Use an in-memory SQLite database for testing
+DATABASE_URL_TEST = "sqlite:///./test_teetimes.db" # Or "sqlite:///:memory:" but file DB is easier to inspect
+engine_test = create_engine(DATABASE_URL_TEST, echo=False) # echo=False for cleaner test output
+
+@pytest.fixture(scope="session", autouse=True)
+def create_test_db():
+    # Create the test database and tables
+    SQLModel.metadata.create_all(engine_test)
+    yield
+    # Teardown: drop all tables or remove the DB file if needed
+    # For simplicity, we can let it recreate if it exists or manage file deletion outside
+    # For in-memory, it's automatically cleared. If file-based, it persists.
+    # Let's try recreating each time for a clean state if file-based.
+    # SQLModel.metadata.drop_all(engine_test) # This might be too aggressive if other sessions use it.
+    # A better approach for file-based is to remove the file after tests run, or ensure clean tables.
+    # For now, create_all is fine. We'll manage test.db manually or clear tables per test.
+
+@pytest.fixture(scope="function") # Use "function" scope for per-test isolation
+def db_session_test():
+    # This fixture provides a test database session.
+    # It creates tables, yields a session, and then clears tables.
+    SQLModel.metadata.create_all(engine_test) # Ensure tables are created for each test
+    connection = engine_test.connect()
+    transaction = connection.begin()
+    session = Session(bind=connection)
+    yield session
+    session.close()
+    transaction.rollback() # Rollback any changes made during the test
+    connection.close()
+    SQLModel.metadata.drop_all(engine_test) # Clean up: drop tables after each test for isolation
+
+@pytest.fixture(scope="function")
+def client_test(db_session_test):
+    # This fixture provides a TestClient for API testing.
+    # It overrides the app's get_session dependency with the test session.
+    def override_get_session():
+        yield db_session_test
+    
+    app.dependency_overrides[get_session] = override_get_session
+    with TestClient(app) as c:
+        yield c
+    app.dependency_overrides.clear() # Clean up overrides

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,242 @@
+# tests/test_db.py
+import pytest
+from sqlmodel import Session
+from typing import List
+
+from src.db import (
+    insert_courses, get_course_by_id, get_courses_by_resort, get_all_courses,
+    insert_tee_times, get_all_tee_times, get_tee_times_by_date,
+    get_tee_times_by_course, get_tee_time_by_id, get_tee_times_by_course_and_date
+)
+from src.models import Course, TeeTime
+
+# Fixture db_session_test is from conftest.py
+
+# --- Test Course DB Functions ---
+
+def test_insert_courses_new(db_session_test: Session):
+    courses_data = [
+        Course(value="CourseDB1", label="CDB1", resort="ResortDB", holes=18, url="http://db1.com"),
+        Course(value="CourseDB2", label="CDB2", resort="ResortDB", holes=9, url="http://db2.com")
+    ]
+    insert_courses(courses_data, db_session_test)
+
+    retrieved_courses = get_all_courses(db_session_test)
+    assert len(retrieved_courses) == 2
+    labels = {c.label for c in retrieved_courses}
+    assert "CDB1" in labels
+    assert "CDB2" in labels
+
+def test_insert_courses_update_existing(db_session_test: Session):
+    course1_v1 = Course(value="UniqueCourseVal", label="OldLabel", resort="OldResort", holes=18, url="http://old.com")
+    insert_courses([course1_v1], db_session_test)
+    
+    retrieved_v1 = get_all_courses(db_session_test)[0]
+    assert retrieved_v1.label == "OldLabel"
+
+    course1_v2 = Course(value="UniqueCourseVal", label="NewLabel", resort="NewResort", holes=18, url="http://new.com")
+    insert_courses([course1_v2], db_session_test)
+
+    retrieved_courses = get_all_courses(db_session_test)
+    assert len(retrieved_courses) == 1 # Should not create a new one
+    retrieved_v2 = retrieved_courses[0]
+    assert retrieved_v2.label == "NewLabel" # Check if updated
+    assert retrieved_v2.resort == "OldResort" # Only label should update based on current insert_courses logic
+
+def test_get_all_courses_empty(db_session_test: Session):
+    courses = get_all_courses(db_session_test)
+    assert courses == []
+
+def test_get_course_by_id(db_session_test: Session):
+    course_data = Course(value="CourseByID", label="CID", resort="ResortID", holes=18, url="http://cid.com")
+    insert_courses([course_data], db_session_test)
+    # Need to get the actual inserted course to know its ID
+    inserted_course = get_all_courses(db_session_test)[0]
+    
+    retrieved_course = get_course_by_id(inserted_course.id, db_session_test)
+    assert retrieved_course is not None
+    assert retrieved_course.label == "CID"
+    
+    assert get_course_by_id(9999, db_session_test) is None
+
+def test_get_courses_by_resort(db_session_test: Session):
+    c1 = Course(value="ResA_C1", label="RAC1", resort="ResortA", holes=18, url="http://ra1.com")
+    c2 = Course(value="ResA_C2", label="RAC2", resort="ResortA", holes=9, url="http://ra2.com")
+    c3 = Course(value="ResB_C1", label="RBC1", resort="ResortB", holes=18, url="http://rb1.com")
+    insert_courses([c1, c2, c3], db_session_test)
+
+    resort_a_courses = get_courses_by_resort("ResortA", db_session_test)
+    assert len(resort_a_courses) == 2
+    resort_b_courses = get_courses_by_resort("ResortB", db_session_test)
+    assert len(resort_b_courses) == 1
+    assert resort_b_courses[0].label == "RBC1"
+    
+    assert get_courses_by_resort("NonExistentResort", db_session_test) == []
+
+# --- Test TeeTime DB Functions ---
+
+def test_insert_tee_times_new(db_session_test: Session):
+    course = Course(value="TT_Course1", label="TTC1", resort="TTResort", holes=18, url="http://ttc1.com")
+    insert_courses([course], db_session_test)
+    db_course = get_all_courses(db_session_test)[0] # Get the course with its ID
+
+    tee_times_data = [
+        TeeTime(course_id=db_course.id, date="2024-07-25", time="10:00", players=4, price=50),
+        TeeTime(course_id=db_course.id, date="2024-07-25", time="10:10", players=2, price=55)
+    ]
+    insert_tee_times(tee_times_data, db_session_test)
+
+    retrieved_tee_times = get_all_tee_times(db_session_test)
+    assert len(retrieved_tee_times) == 2
+    times = {tt.time for tt in retrieved_tee_times}
+    assert "10:00" in times
+    assert "10:10" in times
+
+def test_insert_tee_times_update_existing(db_session_test: Session):
+    course = Course(value="TT_Course_Upd", label="TTC_U", resort="TTResortU", holes=18, url="http://ttcu.com")
+    insert_courses([course], db_session_test)
+    db_course = get_all_courses(db_session_test)[0]
+
+    tt_v1 = TeeTime(course_id=db_course.id, date="2024-07-26", time="11:00", players=2, price=30)
+    insert_tee_times([tt_v1], db_session_test)
+    retrieved_v1 = get_all_tee_times(db_session_test)[0]
+    assert retrieved_v1.players == 2
+    assert retrieved_v1.price == 30
+
+    tt_v2 = TeeTime(course_id=db_course.id, date="2024-07-26", time="11:00", players=4, price=35) # Same key, different players/price
+    insert_tee_times([tt_v2], db_session_test)
+    
+    all_tts = get_all_tee_times(db_session_test)
+    assert len(all_tts) == 1 # Should update, not insert new
+    retrieved_v2 = all_tts[0]
+    assert retrieved_v2.players == 4
+    assert retrieved_v2.price == 35
+
+def test_get_all_tee_times_empty(db_session_test: Session):
+    tts = get_all_tee_times(db_session_test)
+    assert tts == []
+
+def test_get_all_tee_times_pagination(db_session_test: Session):
+    course = Course(value="TT_Course_Pag", label="TTC_P", resort="TTResortP", holes=18, url="http://ttcp.com")
+    insert_courses([course], db_session_test)
+    db_course = get_all_courses(db_session_test)[0]
+
+    for i in range(5):
+        insert_tee_times([TeeTime(course_id=db_course.id, date="2024-07-27", time=f"10:0{i}", players=2, price=20+i)], db_session_test)
+    
+    tts_page1 = get_all_tee_times(db_session_test, skip=0, limit=3)
+    assert len(tts_page1) == 3
+    tts_page2 = get_all_tee_times(db_session_test, skip=3, limit=3)
+    assert len(tts_page2) == 2
+
+def test_get_tee_time_by_id(db_session_test: Session):
+    course = Course(value="TT_Course_ID", label="TTC_ID", resort="TTResortID", holes=18, url="http://ttcid.com")
+    insert_courses([course], db_session_test)
+    db_course = get_all_courses(db_session_test)[0]
+    
+    tt_data = TeeTime(course_id=db_course.id, date="2024-07-28", time="12:00", players=3, price=40)
+    insert_tee_times([tt_data], db_session_test)
+    inserted_tt = get_all_tee_times(db_session_test)[0] # Get the actual tee time with ID
+
+    retrieved_tt = get_tee_time_by_id(inserted_tt.id, db_session_test)
+    assert retrieved_tt is not None
+    assert retrieved_tt.time == "12:00"
+    assert get_tee_time_by_id(9999, db_session_test) is None
+
+def test_get_tee_times_by_date(db_session_test: Session):
+    course = Course(value="TT_Course_Date", label="TTC_D", resort="TTResortD", holes=18, url="http://ttcd.com")
+    insert_courses([course], db_session_test)
+    db_course = get_all_courses(db_session_test)[0]
+
+    tt1 = TeeTime(course_id=db_course.id, date="2024-07-29", time="13:00", players=2, price=30)
+    tt2 = TeeTime(course_id=db_course.id, date="2024-07-29", time="14:00", players=4, price=50)
+    tt3 = TeeTime(course_id=db_course.id, date="2024-07-30", time="15:00", players=3, price=40)
+    insert_tee_times([tt1, tt2, tt3], db_session_test)
+
+    date1_tts = get_tee_times_by_date("2024-07-29", db_session_test)
+    assert len(date1_tts) == 2
+    date2_tts = get_tee_times_by_date("2024-07-30", db_session_test)
+    assert len(date2_tts) == 1
+    assert date2_tts[0].time == "15:00"
+    assert get_tee_times_by_date("2024-08-01", db_session_test) == []
+
+def test_get_tee_times_by_course(db_session_test: Session):
+    c1 = Course(value="TTC_C1", label="TTC1", resort="TTC_Res", holes=18, url="http://ttcc1.com")
+    c2 = Course(value="TTC_C2", label="TTC2", resort="TTC_Res", holes=18, url="http://ttcc2.com")
+    insert_courses([c1, c2], db_session_test)
+    db_c1 = get_all_courses(db_session_test)[0]
+    db_c2 = get_all_courses(db_session_test)[1]
+
+
+    tt_c1 = TeeTime(course_id=db_c1.id, date="2024-07-31", time="16:00", players=2, price=30)
+    tt_c2 = TeeTime(course_id=db_c2.id, date="2024-07-31", time="17:00", players=4, price=50)
+    insert_tee_times([tt_c1, tt_c2], db_session_test)
+
+    c1_tts = get_tee_times_by_course(db_c1.id, db_session_test)
+    assert len(c1_tts) == 1
+    assert c1_tts[0].time == "16:00"
+    
+    c2_tts = get_tee_times_by_course(db_c2.id, db_session_test)
+    assert len(c2_tts) == 1
+    assert c2_tts[0].time == "17:00"
+    
+    assert get_tee_times_by_course(9999, db_session_test) == [] # Non-existent course_id
+
+def test_get_tee_times_by_course_and_date(db_session_test: Session):
+    c1 = Course(value="TTC_CD1", label="TCD1", resort="TCD_Res", holes=18, url="http://tccd1.com")
+    insert_courses([c1], db_session_test)
+    db_c1 = get_all_courses(db_session_test)[0]
+
+    tt1 = TeeTime(course_id=db_c1.id, date="2024-08-01", time="09:00", players=2, price=30)
+    tt2 = TeeTime(course_id=db_c1.id, date="2024-08-01", time="10:00", players=4, price=50) # Same course, same date
+    tt3 = TeeTime(course_id=db_c1.id, date="2024-08-02", time="11:00", players=3, price=40) # Same course, diff date
+    insert_tee_times([tt1, tt2, tt3], db_session_test)
+
+    res_d1 = get_tee_times_by_course_and_date(db_c1.id, "2024-08-01", db_session_test)
+    assert len(res_d1) == 2
+    
+    res_d2 = get_tee_times_by_course_and_date(db_c1.id, "2024-08-02", db_session_test)
+    assert len(res_d2) == 1
+    assert res_d2[0].time == "11:00"
+
+    assert get_tee_times_by_course_and_date(db_c1.id, "2024-08-03", db_session_test) == [] # Correct course, wrong date
+    assert get_tee_times_by_course_and_date(9999, "2024-08-01", db_session_test) == [] # Wrong course, correct date
+
+def test_pagination_for_filtered_queries(db_session_test: Session):
+    course = Course(value="TT_Course_FiltPag", label="TTC_FP", resort="TTResortFP", holes=18, url="http://ttcfp.com")
+    insert_courses([course], db_session_test)
+    db_course = get_all_courses(db_session_test)[0]
+    target_date = "2024-08-05"
+
+    for i in range(5):
+        insert_tee_times([TeeTime(course_id=db_course.id, date=target_date, time=f"11:0{i}", players=2, price=20+i)], db_session_test)
+    insert_tee_times([TeeTime(course_id=db_course.id, date="2024-08-06", time="12:00", players=2, price=30)], db_session_test) # Different date
+
+    # Test get_tee_times_by_date with pagination
+    tts_date_p1 = get_tee_times_by_date(target_date, db_session_test, skip=0, limit=3)
+    assert len(tts_date_p1) == 3
+    tts_date_p2 = get_tee_times_by_date(target_date, db_session_test, skip=3, limit=3)
+    assert len(tts_date_p2) == 2
+
+    # Test get_tee_times_by_course with pagination
+    tts_course_p1 = get_tee_times_by_course(db_course.id, db_session_test, skip=0, limit=3)
+    assert len(tts_course_p1) == 3 # Includes the one from 2024-08-06 for this course
+    # Re-evaluate: get_tee_times_by_course will fetch all for this course, so 6 total
+    # This needs to be adjusted if we only want for `target_date`
+    # The previous loop created 5 for target_date, and 1 for 2024-08-06. Total 6 for db_course.id
+    
+    # Correcting based on actual data:
+    all_for_course = get_tee_times_by_course(db_course.id, db_session_test, limit=10) # Get all for this course
+    assert len(all_for_course) == 6 
+    
+    tts_course_p1_corrected = get_tee_times_by_course(db_course.id, db_session_test, skip=0, limit=4)
+    assert len(tts_course_p1_corrected) == 4
+    tts_course_p2_corrected = get_tee_times_by_course(db_course.id, db_session_test, skip=4, limit=4)
+    assert len(tts_course_p2_corrected) == 2
+
+
+    # Test get_tee_times_by_course_and_date with pagination
+    tts_course_date_p1 = get_tee_times_by_course_and_date(db_course.id, target_date, db_session_test, skip=0, limit=3)
+    assert len(tts_course_date_p1) == 3
+    tts_course_date_p2 = get_tee_times_by_course_and_date(db_course.id, target_date, db_session_test, skip=3, limit=3)
+    assert len(tts_course_date_p2) == 2

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -1,0 +1,218 @@
+# tests/test_services.py
+import pytest
+from unittest.mock import patch, MagicMock, call # Added call for checking multiple calls
+from sqlmodel import Session # For type hinting if needed, though db_session_test is used
+
+from src.services.scraping_service import (
+    aggregate_and_deduplicate_tee_times,
+    run_scheduled_scrape,
+    COURSES as SERVICE_COURSES # Import the constant from the service
+)
+from src.models import TeeTime, Course
+
+# Fixture db_session_test is from conftest.py, though not strictly needed for all service tests
+# if DB interactions are fully mocked. However, run_scheduled_scrape takes a db session.
+
+def test_aggregate_and_deduplicate_tee_times():
+    # Create TeeTime objects, ensuring course_id is set as it's part of the uniqueness key
+    tt1 = TeeTime(date="2024-08-01", time="10:00", course_id=1, players=2, price=50)
+    tt2 = TeeTime(date="2024-08-01", time="10:00", course_id=1, players=4, price=55) # Duplicate of tt1
+    tt3 = TeeTime(date="2024-08-01", time="11:00", course_id=1, players=3, price=60) # Unique time
+    tt4 = TeeTime(date="2024-08-01", time="10:00", course_id=2, players=2, price=50) # Unique course_id
+    tt5 = TeeTime(date="2024-08-02", time="10:00", course_id=1, players=2, price=50) # Unique date
+
+    input_tee_times = [tt1, tt2, tt3, tt4, tt5]
+    deduped_list = aggregate_and_deduplicate_tee_times(input_tee_times)
+
+    assert len(deduped_list) == 4 # tt2 should be removed
+    
+    # Create a list of tuples for easier comparison, as model instances won't be identical
+    # if __eq__ is not defined to compare by values.
+    # The key for uniqueness is (date, time, course_id)
+    expected_unique_keys = {
+        ("2024-08-01", "10:00", 1), # tt1 (tt2 is a duplicate of this)
+        ("2024-08-01", "11:00", 1), # tt3
+        ("2024-08-01", "10:00", 2), # tt4
+        ("2024-08-02", "10:00", 1)  # tt5
+    }
+    
+    output_keys = {(tt.date, tt.time, tt.course_id) for tt in deduped_list}
+    assert output_keys == expected_unique_keys
+
+    # Check that the first encountered version of a duplicate is kept (tt1, not tt2)
+    # This depends on the stability of the loop and list processing in the function.
+    # The current implementation naturally keeps the first one encountered.
+    kept_tt1_equivalent = next(tt for tt in deduped_list if tt.date == "2024-08-01" and tt.time == "10:00" and tt.course_id == 1)
+    assert kept_tt1_equivalent.players == 2 # tt1's player count
+    assert kept_tt1_equivalent.price == 50 # tt1's price
+
+
+@patch("src.services.scraping_service.db_insert_courses")
+@patch("src.services.scraping_service.db_get_courses_by_resort")
+@patch("src.services.scraping_service.fetch_bally_tee_times") # Example fetcher
+@patch("src.services.scraping_service.scrape_bally_tee_times") # Example scraper
+@patch("src.services.scraping_service.fetch_pippy_tee_times") 
+@patch("src.services.scraping_service.scrape_pippy_tee_times")
+@patch("src.services.scraping_service.fetch_glendenning_tee_times")
+@patch("src.services.scraping_service.scrape_glendenning_tee_times")
+@patch("src.services.scraping_service.fetch_wilds_tee_times")
+@patch("src.services.scraping_service.scrape_wilds_tee_times")
+@patch("src.services.scraping_service.aggregate_and_deduplicate_tee_times") # Mock this too
+@patch("src.services.scraping_service.db_insert_tee_times")
+def test_run_scheduled_scrape_logic(
+    mock_db_insert_tee_times,
+    mock_aggregate_deduplicate,
+    mock_scrape_wilds, mock_fetch_wilds, # Order matters for mock objects if not named
+    mock_scrape_glendenning, mock_fetch_glendenning,
+    mock_scrape_pippy, mock_fetch_pippy,
+    mock_scrape_bally, mock_fetch_bally,
+    mock_db_get_courses_by_resort,
+    mock_db_insert_courses,
+    db_session_test: Session # Use the actual test session
+):
+    scrape_date = "2024-08-10"
+
+    # --- Mock Configurations ---
+    # Mock db_get_courses_by_resort to return specific courses for each resort type
+    # These Course objects need 'id' and other attributes used by the service.
+    # The SERVICE_COURSES from scraping_service.py are used by db_insert_courses,
+    # so we can simulate that they've been inserted and given IDs.
+    
+    # Simulate that courses have IDs after insertion
+    mock_bally_course = Course(id=1, value="Championship SOUTH", label="Championship-SOUTH", resort="Bally Haly", holes=18, url="...")
+    mock_pippy_course = Course(id=2, value="Admirals Green", label="ADMIRALS_GREEN", resort="Pippy Park", holes=18, url="...")
+    mock_glendenning_course = Course(id=3, value="Glendenning", label="GLEDENNING", resort="Glendenning", holes=18, url="...")
+    mock_wilds_course = Course(id=4, value="The Wilds", label="THE_WILDS", resort="The Wilds", holes=18, url="...")
+
+    def get_courses_side_effect(resort_name, db_session):
+        if resort_name == "Bally Haly":
+            return [mock_bally_course]
+        if resort_name == "Pippy Park":
+            return [mock_pippy_course]
+        if resort_name == "Glendenning":
+            return [mock_glendenning_course]
+        if resort_name == "The Wilds":
+            return [mock_wilds_course]
+        return []
+    mock_db_get_courses_by_resort.side_effect = get_courses_side_effect
+
+    # Mock fetch and scrape functions to return some dummy data
+    mock_fetch_bally.return_value = "raw_bally_data"
+    mock_scrape_bally.return_value = [TeeTime(course_id=1, date=scrape_date, time="10:00", players=2, price=50)]
+    
+    mock_fetch_pippy.return_value = "raw_pippy_data"
+    mock_scrape_pippy.return_value = [TeeTime(course_id=2, date=scrape_date, time="11:00", players=3, price=60)]
+
+    mock_fetch_glendenning.return_value = "raw_glendenning_data"
+    mock_scrape_glendenning.return_value = [] # Simulate no tee times found
+
+    mock_fetch_wilds.return_value = "raw_wilds_data"
+    mock_scrape_wilds.return_value = [TeeTime(course_id=4, date=scrape_date, time="12:00", players=4, price=70)]
+
+    # Mock aggregate_and_deduplicate_tee_times to return its input directly or a known list
+    # The important part is that it's called with the combined list of scraped tee times.
+    # Let's say it returns a list of 3 unique tee times (Bally, Pippy, Wilds)
+    final_deduped_list = [
+        TeeTime(course_id=1, date=scrape_date, time="10:00", players=2, price=50),
+        TeeTime(course_id=2, date=scrape_date, time="11:00", players=3, price=60),
+        TeeTime(course_id=4, date=scrape_date, time="12:00", players=4, price=70)
+    ]
+    mock_aggregate_deduplicate.return_value = final_deduped_list
+    
+    # --- Call the service function ---
+    run_scheduled_scrape(db=db_session_test, scrape_date=scrape_date)
+
+    # --- Assertions ---
+    # 1. db_insert_courses was called with the SERVICE_COURSES constant and the session
+    mock_db_insert_courses.assert_called_once_with(SERVICE_COURSES, db_session_test)
+
+    # 2. db_get_courses_by_resort was called for each resort type
+    expected_resort_calls = [
+        call("Bally Haly", db_session_test),
+        call("Pippy Park", db_session_test),
+        call("Glendenning", db_session_test),
+        call("The Wilds", db_session_test)
+    ]
+    mock_db_get_courses_by_resort.assert_has_calls(expected_resort_calls, any_order=True) # any_order True because dict iteration order isn't guaranteed for older Python
+
+    # 3. Fetch and scrape functions were called for each course that was "found"
+    mock_fetch_bally.assert_called_once_with(scrape_date, mock_bally_course)
+    mock_scrape_bally.assert_called_once_with("raw_bally_data", mock_bally_course, scrape_date)
+
+    mock_fetch_pippy.assert_called_once_with(scrape_date, mock_pippy_course)
+    mock_scrape_pippy.assert_called_once_with("raw_pippy_data", mock_pippy_course, scrape_date)
+    
+    mock_fetch_glendenning.assert_called_once_with(scrape_date, mock_glendenning_course)
+    mock_scrape_glendenning.assert_called_once_with("raw_glendenning_data", mock_glendenning_course, scrape_date)
+
+    mock_fetch_wilds.assert_called_once_with(scrape_date, mock_wilds_course)
+    mock_scrape_wilds.assert_called_once_with("raw_wilds_data", mock_wilds_course, scrape_date)
+
+    # 4. aggregate_and_deduplicate_tee_times was called with all scraped tee times
+    # The expected list passed to aggregate should be the concatenation of scrape_*.return_value
+    # where course_id is correctly set. The mock_scrape_*.return_value already has course_id.
+    expected_aggregate_input = (
+        mock_scrape_bally.return_value + 
+        mock_scrape_pippy.return_value + 
+        mock_scrape_glendenning.return_value + # This is an empty list in our mock
+        mock_scrape_wilds.return_value
+    )
+    # The TeeTime objects in the actual call will have their course_id field populated by the service logic.
+    # The mock_scrape_*.return_value should reflect this.
+    # Let's verify the content of the list passed to mock_aggregate_deduplicate.
+    # The call object is mock_aggregate_deduplicate.call_args[0][0]
+    actual_aggregate_input = mock_aggregate_deduplicate.call_args[0][0]
+    
+    # Compare elements carefully, as list of objects might not compare directly if objects are different instances.
+    assert len(actual_aggregate_input) == len(expected_aggregate_input)
+    # For a more robust check, compare key attributes of each TeeTime
+    for actual_tt, expected_tt in zip(sorted(actual_aggregate_input, key=lambda x: x.course_id), sorted(expected_aggregate_input, key=lambda x: x.course_id)):
+        assert actual_tt.course_id == expected_tt.course_id
+        assert actual_tt.date == expected_tt.date
+        assert actual_tt.time == expected_tt.time
+        assert actual_tt.players == expected_tt.players
+        assert actual_tt.price == expected_tt.price
+
+
+    # 5. db_insert_tee_times was called with the result from aggregate_and_deduplicate_tee_times
+    mock_db_insert_tee_times.assert_called_once_with(final_deduped_list, db_session_test)
+
+
+def test_run_scheduled_scrape_no_courses_found(
+    mock_db_insert_tee_times: MagicMock, # Need to pass these to the decorator
+    mock_aggregate_deduplicate: MagicMock,
+    mock_scrape_wilds: MagicMock, mock_fetch_wilds: MagicMock,
+    mock_scrape_glendenning: MagicMock, mock_fetch_glendenning: MagicMock,
+    mock_scrape_pippy: MagicMock, mock_fetch_pippy: MagicMock,
+    mock_scrape_bally: MagicMock, mock_fetch_bally: MagicMock,
+    mock_db_get_courses_by_resort: MagicMock,
+    mock_db_insert_courses: MagicMock,
+    db_session_test: Session
+):
+    scrape_date = "2024-08-11"
+    mock_db_get_courses_by_resort.return_value = [] # Simulate no courses found for any resort
+
+    run_scheduled_scrape(db=db_session_test, scrape_date=scrape_date)
+
+    mock_db_insert_courses.assert_called_once_with(SERVICE_COURSES, db_session_test)
+    
+    # Fetch/scrape functions should not be called if no courses
+    mock_fetch_bally.assert_not_called()
+    mock_scrape_bally.assert_not_called()
+    mock_fetch_pippy.assert_not_called()
+    # ... and so on for other scrapers
+
+    # Aggregate should be called with an empty list
+    mock_aggregate_deduplicate.assert_called_once_with([])
+    
+    # Insert tee times should be called with the result of aggregation (empty list)
+    # or not called at all if there's a guard for empty list.
+    # Current implementation of run_scheduled_scrape:
+    # if deduped_tee_times: db_insert_tee_times(...) else: print("No new unique tee times to insert.")
+    # So, if aggregate returns empty list, insert_tee_times should not be called.
+    mock_db_insert_tee_times.assert_not_called() # Assuming aggregate returns empty list
+    
+    # If aggregate itself returns an empty list:
+    mock_aggregate_deduplicate.return_value = []
+    run_scheduled_scrape(db=db_session_test, scrape_date=scrape_date) # Call again with this condition
+    mock_db_insert_tee_times.assert_not_called() # Verify this path too

--- a/tests/test_tee_times.py
+++ b/tests/test_tee_times.py
@@ -1,0 +1,261 @@
+# tests/test_tee_times.py
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+from src.models import Course, TeeTime # Import your models
+from datetime import datetime as dt, date as py_date, timedelta
+from unittest.mock import patch
+
+# client_test and db_session_test are fixtures from conftest.py
+
+def test_read_root(client_test: TestClient):
+    response = client_test.get("/")
+    assert response.status_code == 200
+    assert response.json() == {"message": "Welcome to the Tee Time API. Navigate to /docs for API documentation."}
+
+# --- Course API Tests ---
+def test_read_all_courses_empty(client_test: TestClient):
+    response = client_test.get("/api/v1/tee-times/courses/") 
+    assert response.status_code == 200
+    assert response.json() == []
+
+def test_create_and_read_course(client_test: TestClient, db_session_test: Session):
+    course_data = {"value": "Test Course", "label": "TestLabel", "resort": "TestResort", "holes": 18, "url": "http://example.com/test"}
+    new_course = Course(**course_data)
+    
+    db_session_test.add(new_course)
+    db_session_test.commit()
+    db_session_test.refresh(new_course)
+
+    assert new_course.id is not None
+
+    # Test read by ID
+    response = client_test.get(f"/api/v1/tee-times/courses/{new_course.id}")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["label"] == "TestLabel"
+    assert data["resort"] == "TestResort"
+    assert data["id"] == new_course.id
+
+    # Test getting all courses
+    response_all = client_test.get("/api/v1/tee-times/courses/")
+    assert response_all.status_code == 200
+    assert len(response_all.json()) == 1
+    assert response_all.json()[0]["label"] == "TestLabel"
+
+def test_course_not_found(client_test: TestClient):
+    response = client_test.get("/api/v1/tee-times/courses/99999")
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Course not found"
+
+def test_read_courses_by_resort(client_test: TestClient, db_session_test: Session):
+    course1_data = {"value": "ResortA Course1", "label": "RAC1", "resort": "ResortA", "holes": 18, "url": "http://example.com/rac1"}
+    course2_data = {"value": "ResortA Course2", "label": "RAC2", "resort": "ResortA", "holes": 9, "url": "http://example.com/rac2"}
+    course3_data = {"value": "ResortB Course1", "label": "RBC1", "resort": "ResortB", "holes": 18, "url": "http://example.com/rbc1"}
+    
+    c1 = Course(**course1_data)
+    c2 = Course(**course2_data)
+    c3 = Course(**course3_data)
+    
+    db_session_test.add_all([c1, c2, c3])
+    db_session_test.commit()
+
+    # Test for ResortA
+    response_a = client_test.get("/api/v1/tee-times/courses/resort/ResortA")
+    assert response_a.status_code == 200
+    data_a = response_a.json()
+    assert len(data_a) == 2
+    labels_a = {item["label"] for item in data_a}
+    assert "RAC1" in labels_a
+    assert "RAC2" in labels_a
+
+    # Test for ResortB
+    response_b = client_test.get("/api/v1/tee-times/courses/resort/ResortB")
+    assert response_b.status_code == 200
+    assert len(response_b.json()) == 1
+    assert response_b.json()[0]["label"] == "RBC1"
+
+    # Test for non-existent resort
+    response_c = client_test.get("/api/v1/tee-times/courses/resort/NonExistentResort")
+    assert response_c.status_code == 404 # Based on router implementation raising 404 if list is empty
+
+# --- Tee Time API Tests ---
+
+def test_read_all_tee_times_empty(client_test: TestClient):
+    response = client_test.get("/api/v1/tee-times/")
+    assert response.status_code == 200
+    assert response.json() == []
+
+def test_create_and_read_tee_time(client_test: TestClient, db_session_test: Session):
+    # 1. Create a Course first
+    course = Course(value="GolfCourse1", label="GC1", resort="ResortX", holes=18, url="http://example.com/gc1")
+    db_session_test.add(course)
+    db_session_test.commit()
+    db_session_test.refresh(course)
+    assert course.id is not None
+
+    # 2. Create a TeeTime associated with that course
+    tee_time_data = {
+        "course_id": course.id,
+        "date": "2024-07-15",
+        "time": "10:00",
+        "players": 4,
+        "price": 50.00
+    }
+    # Create TeeTime model instance (assuming direct creation for now, not via API)
+    new_tee_time = TeeTime(**tee_time_data)
+    db_session_test.add(new_tee_time)
+    db_session_test.commit()
+    db_session_test.refresh(new_tee_time)
+    assert new_tee_time.id is not None
+
+    # 3. Test GET /api/v1/tee-times/{tee_time_id}
+    response_single = client_test.get(f"/api/v1/tee-times/{new_tee_time.id}")
+    assert response_single.status_code == 200
+    data_single = response_single.json()
+    assert data_single["id"] == new_tee_time.id
+    assert data_single["date"] == "2024-07-15"
+    assert data_single["time"] == "10:00"
+    assert data_single["course_id"] == course.id
+
+    # 4. Test GET /api/v1/tee-times/ (should list the created tee time)
+    response_all = client_test.get("/api/v1/tee-times/")
+    assert response_all.status_code == 200
+    data_all = response_all.json()
+    assert len(data_all) == 1
+    assert data_all[0]["id"] == new_tee_time.id
+
+def test_read_tee_times_by_date(client_test: TestClient, db_session_test: Session):
+    course = Course(value="DateCourse", label="DC", resort="DateResort", holes=18, url="http://example.com/dc")
+    db_session_test.add(course)
+    db_session_test.commit()
+    db_session_test.refresh(course)
+
+    tt1 = TeeTime(course_id=course.id, date="2024-07-16", time="08:00", players=2, price=30)
+    tt2 = TeeTime(course_id=course.id, date="2024-07-16", time="09:00", players=4, price=50)
+    tt3 = TeeTime(course_id=course.id, date="2024-07-17", time="10:00", players=3, price=40)
+    db_session_test.add_all([tt1, tt2, tt3])
+    db_session_test.commit()
+
+    # Test for date with tee times
+    response_with = client_test.get("/api/v1/tee-times/date/2024-07-16")
+    assert response_with.status_code == 200
+    data_with = response_with.json()
+    assert len(data_with) == 2
+    times_retrieved = {item["time"] for item in data_with}
+    assert "08:00" in times_retrieved
+    assert "09:00" in times_retrieved
+
+    # Test for date without tee times
+    response_without = client_test.get("/api/v1/tee-times/date/2024-07-18")
+    assert response_without.status_code == 200
+    assert response_without.json() == []
+
+    # Test with invalid date format
+    response_invalid = client_test.get("/api/v1/tee-times/date/invalid-date")
+    assert response_invalid.status_code == 400
+    assert response_invalid.json()["detail"] == "Invalid date format. Use YYYY-MM-DD."
+
+def test_read_tee_times_by_course(client_test: TestClient, db_session_test: Session):
+    course1 = Course(value="CourseA", label="CA", resort="ResortCommon", holes=18, url="http://example.com/ca")
+    course2 = Course(value="CourseB", label="CB", resort="ResortCommon", holes=18, url="http://example.com/cb")
+    db_session_test.add_all([course1, course2])
+    db_session_test.commit()
+    db_session_test.refresh(course1)
+    db_session_test.refresh(course2)
+
+    tt_c1_1 = TeeTime(course_id=course1.id, date="2024-07-19", time="11:00", players=2, price=30)
+    tt_c1_2 = TeeTime(course_id=course1.id, date="2024-07-19", time="12:00", players=4, price=50)
+    tt_c2_1 = TeeTime(course_id=course2.id, date="2024-07-19", time="13:00", players=3, price=40)
+    db_session_test.add_all([tt_c1_1, tt_c1_2, tt_c2_1])
+    db_session_test.commit()
+
+    # Test for Course1
+    response_c1 = client_test.get(f"/api/v1/tee-times/course/{course1.id}")
+    assert response_c1.status_code == 200
+    data_c1 = response_c1.json()
+    assert len(data_c1) == 2
+    c1_times = {item["time"] for item in data_c1}
+    assert "11:00" in c1_times
+    assert "12:00" in c1_times
+
+    # Test for Course2
+    response_c2 = client_test.get(f"/api/v1/tee-times/course/{course2.id}")
+    assert response_c2.status_code == 200
+    assert len(response_c2.json()) == 1
+    assert response_c2.json()[0]["time"] == "13:00"
+
+    # Test for non-existent course ID (valid format, but doesn't exist)
+    response_non_existent = client_test.get("/api/v1/tee-times/course/99999")
+    assert response_non_existent.status_code == 200 # API returns empty list if course has no tee times or course does not exist
+    assert response_non_existent.json() == []
+
+
+def test_read_tee_times_by_course_and_date(client_test: TestClient, db_session_test: Session):
+    course = Course(value="CourseDateTime", label="CDT", resort="ResortDT", holes=18, url="http://example.com/cdt")
+    db_session_test.add(course)
+    db_session_test.commit()
+    db_session_test.refresh(course)
+
+    tt1 = TeeTime(course_id=course.id, date="2024-07-20", time="14:00", players=2, price=30)
+    tt2 = TeeTime(course_id=course.id, date="2024-07-20", time="15:00", players=4, price=50)
+    tt3 = TeeTime(course_id=course.id, date="2024-07-21", time="16:00", players=3, price=40) # Different date
+    db_session_test.add_all([tt1, tt2, tt3])
+    db_session_test.commit()
+
+    # Test for course and specific date with tee times
+    response_match = client_test.get(f"/api/v1/tee-times/course/{course.id}/date/2024-07-20")
+    assert response_match.status_code == 200
+    data_match = response_match.json()
+    assert len(data_match) == 2
+    match_times = {item["time"] for item in data_match}
+    assert "14:00" in match_times
+    assert "15:00" in match_times
+
+    # Test for course and date with no tee times
+    response_no_match_date = client_test.get(f"/api/v1/tee-times/course/{course.id}/date/2024-07-22")
+    assert response_no_match_date.status_code == 200
+    assert response_no_match_date.json() == []
+    
+    # Test with invalid date format
+    response_invalid_date = client_test.get(f"/api/v1/tee-times/course/{course.id}/date/invalid-date-format")
+    assert response_invalid_date.status_code == 400
+    assert response_invalid_date.json()["detail"] == "Invalid date format. Use YYYY-MM-DD."
+
+def test_tee_time_not_found(client_test: TestClient):
+    response = client_test.get("/api/v1/tee-times/88888") # Non-existent ID
+    assert response.status_code == 404
+    assert response.json()["detail"] == "TeeTime not found"
+
+# --- Scraping Trigger Endpoint Test ---
+
+def test_trigger_scrape_endpoint(client_test: TestClient, db_session_test: Session): # Added db_session_test
+    # Patch where 'run_scheduled_scrape' is looked up (i.e., in the router module)
+    with patch("src.routers.tee_times_router.run_scheduled_scrape") as mock_run_scrape:
+        # Test without date parameter (should default to today)
+        response_no_date = client_test.post("/api/v1/tee-times/scrape")
+        assert response_no_date.status_code == 200
+        json_response_no_date = response_no_date.json()
+        assert "Scraping process initiated" in json_response_no_date["message"]
+        today_str = py_date.today().strftime("%Y-%m-%d")
+        assert json_response_no_date["scrape_date"] == today_str
+        mock_run_scrape.assert_called_with(db_session_test, today_str) # db_session_test is passed by Depends
+
+        mock_run_scrape.reset_mock()
+
+        # Test with a specific valid date parameter
+        scrape_date_param = "2025-01-01"
+        response_with_date = client_test.post(f"/api/v1/tee-times/scrape?scrape_date_str={scrape_date_param}")
+        assert response_with_date.status_code == 200
+        json_response_with_date = response_with_date.json()
+        assert "Scraping process initiated" in json_response_with_date["message"]
+        assert json_response_with_date["scrape_date"] == scrape_date_param
+        mock_run_scrape.assert_called_with(db_session_test, scrape_date_param)
+
+        mock_run_scrape.reset_mock()
+
+        # Test with an invalid date format
+        invalid_date_param = "01-01-2025"
+        response_invalid_date = client_test.post(f"/api/v1/tee-times/scrape?scrape_date_str={invalid_date_param}")
+        assert response_invalid_date.status_code == 400
+        assert "Invalid date format" in response_invalid_date.json()["detail"]
+        mock_run_scrape.assert_not_called()


### PR DESCRIPTION
This commit introduces a FastAPI application that provides endpoints for managing and accessing golf tee time data.

Key features include:
- FastAPI backend with a structured project layout (database, services, routers).
- SQLModel for database interaction (SQLite) and Pydantic model validation.
- Scraping service to fetch tee times from various course websites using Playwright and Selectolax.
- API Endpoints:
    - Trigger scraping process (manual refresh via POST request).
    - Read-only access to course information (all, by ID, by resort).
    - Read-only access to tee time information (all, by ID, by date, by course), with pagination.
- Comprehensive unit and integration tests for API endpoints, database logic, and service functions using pytest.
- Auto-generated API documentation (Swagger UI & ReDoc) enhanced with summaries, descriptions, and response models.

The existing scraping logic has been refactored into services, and the application is now served via Uvicorn.